### PR TITLE
try fixing &-deleting bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@
     var pauseDelay = opts.delay || opts.pauseDelay || 2000;
     var postfix = opts.postfix || '';
     var getter = opts.getter || function(elem) {
-      return elem.innerHTML;
+      return elem.textContent;
     };
     var setter = opts.setter || function(elem, val) {
-      elem.innerHTML = val;
+      elem.textContent = val;
     };
 
     // the function queue


### PR DESCRIPTION
Using `textContent` instead of `innerHTML` fixes the bug when deleting HTML entities.

However, textContent raises the browser compatibility to IE9.
An alternative is to use innerText which, however, ignore trailing white spaces, so more checks should be done.